### PR TITLE
修复当Deck名称包含空格时无法正确识别duplicates的问题

### DIFF
--- a/core/gui.py
+++ b/core/gui.py
@@ -178,7 +178,7 @@ class WordLoader(QRunnable):
                 common_log(f'获取到单词{r.title}')
             else:
                 try:
-                    note_dupes = mw.col.find_notes(f'deck:{self.deck_name} and target_id:{r.target_id}')
+                    note_dupes = mw.col.find_notes(f'deck:"{self.deck_name}" and target_id:{r.target_id}')
                 except Exception:
                     common_log('查询单词异常:' + json.dumps(r.__dict__, ensure_ascii=False))
                     raise


### PR DESCRIPTION
当deck名称有空格时，find_notes找不到卡片，需要加引号