### PR TITLE
修复1.1.0版本中默认收藏夹只能抓取第一页的问题

### DIFF
--- a/core/mojidict_server.py
+++ b/core/mojidict_server.py
@@ -163,5 +163,5 @@ class MojiServer:
             for mojiword in mojiwords:
                 yield mojiword
             page_index += 1
-            if not mojiwords or page_index > total_page:
+            if not mojiwords or (dir_id and page_index > total_page):
                 break


### PR DESCRIPTION
默认收藏夹URL_COLLECTION的post请求不会返回真实的总页数，返回的json中totalPage永远是0，所以1.1.0版本增加的一个页数判断导致了默认收藏夹只能抓取第一页