### PR TITLE
修复Anki 23.10.1版本后插件无法正常加载的问题

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QAction
+from aqt.qt import QAction
 from anki import hooks
 from aqt import mw, gui_hooks
 

--- a/core/gui.py
+++ b/core/gui.py
@@ -7,9 +7,9 @@ import time
 import typing
 from collections import deque
 
-from PyQt5 import QtGui
-from PyQt5.QtCore import QThreadPool, pyqtSignal, pyqtSlot, QRunnable, QThread, QObject
-from PyQt5.QtWidgets import QDialog, QLabel, QLineEdit, QPushButton, QFormLayout, QVBoxLayout, QHBoxLayout, \
+from aqt.qt import QCloseEvent
+from aqt.qt import QThreadPool, pyqtSignal, pyqtSlot, QRunnable, QThread, QObject
+from aqt.qt import QDialog, QLabel, QLineEdit, QPushButton, QFormLayout, QVBoxLayout, QHBoxLayout, \
     QGridLayout, QPlainTextEdit, QMessageBox, QCheckBox, QGroupBox
 
 from . import storage, common, anki, operations
@@ -255,7 +255,7 @@ class ImportWindow(QDialog):
         else:
             QMessageBox.critical(self, '', 'Deck名称和Note名称必填')
 
-    def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
+    def closeEvent(self, a0: QCloseEvent) -> None:
         if self.word_loader:
             self.word_loader.interrupt()
         self.thread_pool.waitForDone()


### PR DESCRIPTION
把 PyQt5 模块的 import 项都改成 aqt.qt 
在 anki mac ⁨23.12beta1 Qt6 测试过可以正常使用了